### PR TITLE
feat: 자동 로그인 구현 및 401 에러 처리

### DIFF
--- a/app/_apis/auth.ts
+++ b/app/_apis/auth.ts
@@ -1,6 +1,6 @@
 import { storage } from '@lib/util/storage';
 
-import { AuthResponse } from '@/_types/auth';
+import { AuthResponse } from '@/_types/response';
 
 import instance from './core';
 

--- a/app/_apis/auth.ts
+++ b/app/_apis/auth.ts
@@ -1,3 +1,6 @@
+import { getCookie } from 'cookies-next';
+
+import { AUTH_TOKEN } from '@/_constants/auth';
 import { AuthResponse } from '@/_types/auth';
 
 import instance from './core';
@@ -15,13 +18,12 @@ export const authApi = {
       },
     }),
   /**
-   * @param refreshToken 쿠키에 담긴 refreshToken
    * @description refreshToken로 accessToken 재발급
    */
-  getRefresh: (refreshToken: string) =>
-    instance.get<string, AuthResponse>(`/auth/refresh`, {
+  silentRefresh: () =>
+    instance.get<unknown, AuthResponse>(`/auth/refresh`, {
       params: {
-        refresh_token: refreshToken,
+        refresh_token: getCookie(AUTH_TOKEN.REFRESH),
       },
     }),
 };

--- a/app/_apis/auth.ts
+++ b/app/_apis/auth.ts
@@ -1,6 +1,5 @@
-import { getCookie } from 'cookies-next';
+import { storage } from '@lib/util/storage';
 
-import { AUTH_TOKEN } from '@/_constants/auth';
 import { AuthResponse } from '@/_types/auth';
 
 import instance from './core';
@@ -23,7 +22,7 @@ export const authApi = {
   silentRefresh: () =>
     instance.get<unknown, AuthResponse>(`/auth/refresh`, {
       params: {
-        refresh_token: getCookie(AUTH_TOKEN.REFRESH),
+        refresh_token: storage.getRefreshToken(),
       },
     }),
 };

--- a/app/_apis/core.ts
+++ b/app/_apis/core.ts
@@ -1,7 +1,6 @@
-import { AUTH_TOKEN, COOKIE_CONFIG } from '@constants/auth';
 import { HTTP_STATUS_CODE } from '@constants/http';
+import { isExpiredAccessToken, storage } from '@lib/util/storage';
 import axios, { type AxiosResponse } from 'axios';
-import { setCookie } from 'cookies-next';
 
 import { authApi } from './auth';
 
@@ -36,10 +35,10 @@ instance.interceptors.response.use(
       const { id_token, refresh_token } = await authApi.silentRefresh();
 
       setAccessToken(id_token);
-      setCookie(AUTH_TOKEN.ACCESS, id_token, COOKIE_CONFIG.ACCESS);
+      storage.setAccessToken(id_token);
 
-      if (refresh_token) {
-        setCookie(AUTH_TOKEN.REFRESH, refresh_token, COOKIE_CONFIG.REFRESH);
+      if (isExpiredAccessToken(refresh_token)) {
+        storage.setRefreshToken(refresh_token);
       }
 
       return axios(originalRequest);

--- a/app/_apis/core.ts
+++ b/app/_apis/core.ts
@@ -4,8 +4,7 @@ import axios, { type AxiosResponse } from 'axios';
 
 import { authApi } from './auth';
 
-export const HTTP_BASE_URL =
-  process.env.NODE_ENV === 'production' ? '' : process.env.NEXT_PUBLIC_LOCAL_BASE_URL;
+export const HTTP_BASE_URL = process.env.NODE_ENV === 'production' ? '' : 'http://localhost:3000';
 
 const options = {
   headers: {
@@ -49,11 +48,11 @@ instance.interceptors.response.use(
 );
 
 export const setAccessToken = (token: string) => {
-  instance.defaults.headers.common['Authorization'] = `Bearer ${token}`;
+  instance.defaults.headers.common.Authorization = `Bearer ${token}`;
 };
 
 export const removeAccessToken = () => {
-  instance.defaults.headers.common['Authorization'] = '';
+  instance.defaults.headers.common.Authorization = '';
 };
 
 export default instance;

--- a/app/_apis/core.ts
+++ b/app/_apis/core.ts
@@ -1,7 +1,7 @@
-import { AUTH_TOKEN } from '@constants/auth';
+import { AUTH_TOKEN, COOKIE_CONFIG } from '@constants/auth';
 import { HTTP_STATUS_CODE } from '@constants/http';
 import axios, { type AxiosResponse } from 'axios';
-import { getCookie, setCookie } from 'cookies-next';
+import { setCookie } from 'cookies-next';
 
 import { authApi } from './auth';
 
@@ -33,15 +33,13 @@ instance.interceptors.response.use(
      * [status:401] Access Token이 만료된 경우 Refresh Token으로 재발급 후, api 재요청
      */
     if (status === HTTP_STATUS_CODE.UNAUTHORIZED) {
-      const refreshToken = getCookie(AUTH_TOKEN.REFRESH) as string;
-
-      const { id_token, refresh_token } = await authApi.getRefresh(refreshToken);
+      const { id_token, refresh_token } = await authApi.silentRefresh();
 
       setAccessToken(id_token);
-      setCookie(AUTH_TOKEN.ACCESS, id_token);
+      setCookie(AUTH_TOKEN.ACCESS, id_token, COOKIE_CONFIG.ACCESS);
 
       if (refresh_token) {
-        setCookie(AUTH_TOKEN.REFRESH, refresh_token);
+        setCookie(AUTH_TOKEN.REFRESH, refresh_token, COOKIE_CONFIG.REFRESH);
       }
 
       return axios(originalRequest);

--- a/app/_apis/member.ts
+++ b/app/_apis/member.ts
@@ -1,3 +1,5 @@
+import { MemberResponse } from '@/_types/response';
+
 import instance from './core';
 
 export interface MemberInfo {
@@ -9,9 +11,10 @@ export const memberApi = {
   /**
    * @description 회원정보 조회
    */
-  getMember: () => instance.get(`/api/member`),
+  getMember: () => instance.get<unknown, MemberResponse>(`/api/member`),
   /**
    * @description 회원정보 등록
    */
-  updateMember: (info: MemberInfo) => instance.post(`/api/member`, info),
+  updateMember: (info: MemberInfo) =>
+    instance.post<MemberInfo, MemberResponse>(`/api/member`, info),
 };

--- a/app/_components/common/Navigation.tsx
+++ b/app/_components/common/Navigation.tsx
@@ -1,9 +1,8 @@
 'use client';
 
+import { ROUTES } from '@constants/routes';
 import { useIsLoggedIn } from '@store/auth';
 import Link from 'next/link';
-
-import { ROUTES } from '@/_constants/routes';
 
 const Navigation = () => {
   const isLoggedIn = useIsLoggedIn();

--- a/app/_components/providers/AuthProvider.tsx
+++ b/app/_components/providers/AuthProvider.tsx
@@ -4,9 +4,11 @@ import { setAccessToken } from '@apis/core';
 import { AUTH_TOKEN } from '@constants/auth';
 import { ROUTES } from '@constants/routes';
 import { useAuthActions, useIsLoggedIn } from '@store/auth';
-import { getCookie } from 'cookies-next';
+import { getCookie, setCookie } from 'cookies-next';
 import { useRouter } from 'next/navigation';
 import { PropsWithChildren, useEffect } from 'react';
+
+import { authApi } from '@/_apis/auth';
 
 export default function AuthProvider({ children }: PropsWithChildren) {
   const router = useRouter();
@@ -25,6 +27,27 @@ export default function AuthProvider({ children }: PropsWithChildren) {
     if (accessToken) {
       setAccessToken(accessToken);
       setIsLoggedIn(true);
+
+      return;
+    }
+
+    /** 로그인 상태는 아니지만 쿠키에 리프레시 토큰이 남아있는 경우, 토큰 재발급 */
+    const refreshToken = getCookie(AUTH_TOKEN.REFRESH) as string;
+
+    if (refreshToken) {
+      (async () => {
+        const { id_token, refresh_token } = await authApi.silentRefresh();
+
+        if (id_token) {
+          setIsLoggedIn(true);
+          setAccessToken(id_token);
+          setCookie(AUTH_TOKEN.ACCESS, id_token);
+        }
+
+        if (refresh_token.length > 0) {
+          setCookie(AUTH_TOKEN.REFRESH, refreshToken);
+        }
+      })();
 
       return;
     }

--- a/app/_constants/auth.ts
+++ b/app/_constants/auth.ts
@@ -4,3 +4,8 @@ export const AUTH_TOKEN = {
   ACCESS: 'accessToken',
   REFRESH: 'refreshToken',
 };
+
+export const COOKIE_CONFIG = {
+  ACCESS: { maxAge: 60 * 60 * 24 },
+  REFRESH: { maxAge: 60 * 60 * 24 * 30 },
+};

--- a/app/_hooks/useKakaoLogin.ts
+++ b/app/_hooks/useKakaoLogin.ts
@@ -1,9 +1,8 @@
 import { authApi } from '@apis/auth';
 import { setAccessToken } from '@apis/core';
-import { AUTH_TOKEN, COOKIE_CONFIG } from '@constants/auth';
 import { ROUTES } from '@constants/routes';
+import { storage } from '@lib/util/storage';
 import { useAuthActions } from '@store/auth';
-import { setCookie } from 'cookies-next';
 import { useRouter } from 'next/navigation';
 import { useState } from 'react';
 
@@ -19,8 +18,9 @@ const useKakaoLogin = () => {
       const { id_token, refresh_token } = await authApi.getToken(code);
 
       setAccessToken(id_token);
-      setCookie(AUTH_TOKEN.ACCESS, id_token, COOKIE_CONFIG.ACCESS);
-      setCookie(AUTH_TOKEN.REFRESH, refresh_token, COOKIE_CONFIG.REFRESH);
+
+      storage.setAccessToken(id_token);
+      storage.setRefreshToken(refresh_token);
 
       setIsLoggedIn(true);
       setIsLoading(false);

--- a/app/_hooks/useKakaoLogin.ts
+++ b/app/_hooks/useKakaoLogin.ts
@@ -1,6 +1,6 @@
 import { authApi } from '@apis/auth';
 import { setAccessToken } from '@apis/core';
-import { AUTH_TOKEN } from '@constants/auth';
+import { AUTH_TOKEN, COOKIE_CONFIG } from '@constants/auth';
 import { ROUTES } from '@constants/routes';
 import { useAuthActions } from '@store/auth';
 import { setCookie } from 'cookies-next';
@@ -19,8 +19,8 @@ const useKakaoLogin = () => {
       const { id_token, refresh_token } = await authApi.getToken(code);
 
       setAccessToken(id_token);
-      setCookie(AUTH_TOKEN.ACCESS, id_token);
-      setCookie(AUTH_TOKEN.REFRESH, refresh_token);
+      setCookie(AUTH_TOKEN.ACCESS, id_token, COOKIE_CONFIG.ACCESS);
+      setCookie(AUTH_TOKEN.REFRESH, refresh_token, COOKIE_CONFIG.REFRESH);
 
       setIsLoggedIn(true);
       setIsLoading(false);

--- a/app/_lib/util/storage.ts
+++ b/app/_lib/util/storage.ts
@@ -1,0 +1,13 @@
+import { AUTH_TOKEN, COOKIE_CONFIG } from '@constants/auth';
+import { getCookie, setCookie } from 'cookies-next';
+
+export const storage = {
+  getAccessToken: () => getCookie(AUTH_TOKEN.ACCESS) as string,
+  getRefreshToken: () => getCookie(AUTH_TOKEN.REFRESH) as string,
+  setAccessToken: (token: string) => setCookie(AUTH_TOKEN.ACCESS, token, COOKIE_CONFIG.ACCESS),
+  setRefreshToken: (token: string) => setCookie(AUTH_TOKEN.REFRESH, token, COOKIE_CONFIG.REFRESH),
+};
+
+export const isExpiredAccessToken = (token: string) => {
+  return token.trim().length > 0;
+};

--- a/app/_types/response.ts
+++ b/app/_types/response.ts
@@ -3,3 +3,9 @@ export interface AuthResponse {
   refresh_token: string;
   nickname: string;
 }
+
+export interface MemberResponse {
+  userId: string;
+  email: string;
+  nickname: string;
+}

--- a/next.config.js
+++ b/next.config.js
@@ -11,6 +11,14 @@ const nextConfig = {
     });
     return config;
   },
+  async rewrites() {
+    return [
+      {
+        source: '/:path*',
+        destination: `${process.env.NEXT_PUBLIC_LOCAL_BASE_URL}/:path*`,
+      },
+    ];
+  },
 };
 
 module.exports = nextConfig;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -29,6 +29,7 @@
       "@store/*": ["./app/_store/*"],
       "@styles/*": ["./app/_styles/*"],
       "@types/*": ["./app/_types/*"],
+      "@lib/*": ["./app/_lib/*"],
       "@assets/*": ["./public/assets/*"],
     }
   },


### PR DESCRIPTION
## 📌 이슈 번호
- close #20 

## ✨ 작업 내용
- [x] 새로고침 시 자동 로그인 구현
- [x] 401 에러 발생 시 토큰 재발급 후 재요청
- [x] 구조 리팩터링 

## 📝 작업 상세 내용
기존 회원 여부를 아직 알 방법이 없어 임시로 카카오 로그인 시 모두 회원가입 페이지로 이동하도록 구현했습니다.

## 🎨 구현 스크린샷

https://github.com/DDD-Community/DDD-9-WEB3-front/assets/76807107/dfcb9a0f-72c0-421e-a35b-910dd7bdb15e


## 💎 TODO
- 카카오 로그인에서 받은 토큰을 이용해 응답으로 받은 닉네임으로 회원 정보를 등록하는 로직 구현
- 로그인 시 기존 회원 여부에 따른 리다이렉트 수정