### PR TITLE
feat: 회원가입, 로그인 로직 구현

### DIFF
--- a/app/(router)/signup/page.tsx
+++ b/app/(router)/signup/page.tsx
@@ -1,5 +1,13 @@
+import { ROUTES } from '@constants/routes';
 import SignupPage from '@features/SignupPage';
+import { LOTTOFOLIO_USER } from '@lib/util/storage';
+import { cookies } from 'next/headers';
+import { redirect } from 'next/navigation';
 
 export default function Page() {
+  if (cookies().get(LOTTOFOLIO_USER)) {
+    redirect(ROUTES.HOME);
+  }
+
   return <SignupPage />;
 }

--- a/app/_apis/auth.ts
+++ b/app/_apis/auth.ts
@@ -22,7 +22,7 @@ export const authApi = {
   silentRefresh: () =>
     instance.get<unknown, AuthResponse>(`/auth/refresh`, {
       params: {
-        refresh_token: storage.getRefreshToken(),
+        refreshToken: storage.getRefreshToken(),
       },
     }),
 };

--- a/app/_apis/core.ts
+++ b/app/_apis/core.ts
@@ -1,5 +1,6 @@
 import { HTTP_STATUS_CODE } from '@constants/http';
-import { isExpiredAccessToken, storage } from '@lib/util/storage';
+import { isExpiredAccessToken, isNotExistAuthHeader, isNotRegisteredMember } from '@lib/util/http';
+import { storage } from '@lib/util/storage';
 import axios, { type AxiosResponse } from 'axios';
 
 import { authApi } from './auth';
@@ -30,23 +31,35 @@ instance.interceptors.response.use(
   async error => {
     const {
       config: originalRequest,
-      response: { status },
+      response: {
+        status,
+        data: { message },
+      },
     } = error;
 
-    /**
-     * [status:401] Access Token이 만료된 경우 Refresh Token으로 재발급 후, api 재요청
-     */
     if (originalRequest && status === HTTP_STATUS_CODE.UNAUTHORIZED) {
-      const { id_token, refresh_token } = await authApi.silentRefresh();
-
-      setAccessToken(id_token);
-      storage.setAccessToken(id_token);
-
-      if (isExpiredAccessToken(refresh_token)) {
-        storage.setRefreshToken(refresh_token);
+      if (isNotRegisteredMember(message)) {
+        /**
+         * [status:401] 등록된 기존 회원이 아닌 경우
+         */
+        return Promise.reject(error);
       }
 
-      return instance(originalRequest);
+      if (isNotExistAuthHeader(message)) {
+        /**
+         * [status:401] 헤더에 token이 없는 경우
+         */
+        const { id_token, refresh_token } = await authApi.silentRefresh();
+
+        setAccessToken(id_token);
+        storage.setAccessToken(id_token);
+
+        if (isExpiredAccessToken(refresh_token)) {
+          storage.setRefreshToken(refresh_token);
+        }
+
+        return instance(originalRequest);
+      }
     }
 
     return Promise.reject(error);

--- a/app/_apis/member.ts
+++ b/app/_apis/member.ts
@@ -4,7 +4,7 @@ import instance from './core';
 
 export interface MemberInfo {
   email: string;
-  nickName: string;
+  nickname: string;
 }
 
 export const memberApi = {
@@ -15,6 +15,16 @@ export const memberApi = {
   /**
    * @description 회원정보 등록
    */
-  updateMember: (info: MemberInfo) =>
+  registerMember: (info: MemberInfo) =>
     instance.post<MemberInfo, MemberResponse>(`/api/member`, info),
+
+  /**
+   * @description 회원정보 삭제
+   */
+  deleteMember: () => instance.delete(`/api/member`),
+  /**
+   * @description 회원정보 수정
+   */
+  updateMember: (info: MemberInfo) =>
+    instance.patch<MemberInfo, MemberResponse>(`/api/member`, info),
 };

--- a/app/_components/providers/AuthProvider.tsx
+++ b/app/_components/providers/AuthProvider.tsx
@@ -3,7 +3,8 @@
 import { authApi } from '@apis/auth';
 import { setAccessToken } from '@apis/core';
 import { ROUTES } from '@constants/routes';
-import { isExpiredAccessToken, storage } from '@lib/util/storage';
+import { isExpiredAccessToken } from '@lib/util/http';
+import { storage } from '@lib/util/storage';
 import { useAuthActions, useIsLoggedIn } from '@store/auth';
 import { useRouter } from 'next/navigation';
 import { PropsWithChildren, useEffect } from 'react';

--- a/app/_constants/auth.ts
+++ b/app/_constants/auth.ts
@@ -6,6 +6,6 @@ export const AUTH_TOKEN = {
 };
 
 export const COOKIE_CONFIG = {
-  ACCESS: { maxAge: 60 * 60 * 24 },
-  REFRESH: { maxAge: 60 * 60 * 24 * 30 },
+  ACCESS: { maxAge: 60 * 60 * 6 },
+  REFRESH: { maxAge: 60 * 60 * 24 * 60 },
 };

--- a/app/_constants/http.ts
+++ b/app/_constants/http.ts
@@ -5,3 +5,8 @@ export const HTTP_STATUS_CODE = {
   NOTFOUND: 404,
   INTERNAL_SERVER_ERROR: 500,
 } as const;
+
+export const HTTP_RESPONSE_ERROR_MESSAGE = {
+  NOT_REGISTERED_MEMBER: '등록된 회원이 아닙니다',
+  NOT_EXIST_AUTH: 'Authorization 헤더가 존재하지 않습니다',
+};

--- a/app/_features/LoginPage.tsx
+++ b/app/_features/LoginPage.tsx
@@ -2,10 +2,8 @@
 
 import IconKakao from '@assets/svg/kakao.svg';
 import { Button } from '@components/common';
-import TopNavigation from '@components/common/TopNavigation';
 import LottoBallSlider from '@components/login/LottoBallSlider';
 import { KAKAO_LOGIN_URL } from '@constants/auth';
-import { ROUTES } from '@constants/routes';
 import palette from '@styles/palette';
 import { useRouter } from 'next/navigation';
 import { styled } from 'styled-components';
@@ -15,7 +13,6 @@ export default function LoginPage() {
 
   return (
     <Wrapper>
-      <TopNavigation version="CLOSE" path={ROUTES.HOME} />
       <div>
         <Intro>안녕하세요 👋</Intro>
         <div>

--- a/app/_features/SignupPage.tsx
+++ b/app/_features/SignupPage.tsx
@@ -1,8 +1,12 @@
 'use client';
 
+import { memberApi } from '@apis/member';
 import { Button, CheckBox } from '@components/common';
 import TopNavigation from '@components/common/TopNavigation';
 import { ROUTES } from '@constants/routes';
+import { storage } from '@lib/util/storage';
+import { useAuthActions } from '@store/auth';
+import { useMemeberInfo } from '@store/member';
 import palette from '@styles/palette';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
@@ -27,6 +31,8 @@ export default function SignupPage() {
   const router = useRouter();
   const [isAllAgreed, setIsAllAgreed] = useState(false);
   const [agreedTerms, setAgreedTerms] = useState(DEFAULT_AGREEDTERMS);
+  const memberInfo = useMemeberInfo();
+  const { setIsLoggedIn } = useAuthActions();
 
   const handleAllAgreeClick = () => {
     setIsAllAgreed(prev => !prev);
@@ -51,12 +57,17 @@ export default function SignupPage() {
     setAgreedTerms(prev => ({ ...prev, [checkedTermId]: !prev[checkedTermId] }));
   };
 
-  const handleSubmitClick = (e: FormEvent<HTMLFormElement>) => {
+  const handleSubmitClick = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
 
     if (!isAllAgreed) {
       return;
     }
+
+    const { user_id } = await memberApi.registerMember(memberInfo);
+
+    storage.setUserId(user_id);
+    setIsLoggedIn(true);
 
     router.push(ROUTES.HOME);
   };

--- a/app/_hooks/useKakaoLogin.ts
+++ b/app/_hooks/useKakaoLogin.ts
@@ -1,8 +1,10 @@
 import { authApi } from '@apis/auth';
 import { setAccessToken } from '@apis/core';
+import { memberApi } from '@apis/member';
 import { ROUTES } from '@constants/routes';
 import { storage } from '@lib/util/storage';
 import { useAuthActions } from '@store/auth';
+import { useMemberActions } from '@store/member';
 import { useRouter } from 'next/navigation';
 import { useState } from 'react';
 
@@ -10,28 +12,37 @@ const useKakaoLogin = () => {
   const router = useRouter();
   const [isLoading, setIsLoading] = useState(false);
   const { setIsLoggedIn } = useAuthActions();
+  const { setMemberInfo } = useMemberActions();
 
   const login = async (code: string) => {
     setIsLoading(true);
 
     try {
-      const { id_token, refresh_token } = await authApi.getToken(code);
+      const { id_token, refresh_token, email, nickname } = await authApi.getToken(code);
 
       setAccessToken(id_token);
 
       storage.setAccessToken(id_token);
       storage.setRefreshToken(refresh_token);
 
-      setIsLoggedIn(true);
-      setIsLoading(false);
+      setMemberInfo({ email, nickname });
 
       /**
        * 회원정보가 없는 경우, 회원가입 페이지로 리다이렉트
        * 회원정보가 있는 경우, 홈으로 리다이렉트
        * */
-      router.push(ROUTES.SIGNUP);
+      const { user_id } = await memberApi.getMember();
+
+      storage.setUserId(user_id);
+
+      setIsLoggedIn(true);
+      setIsLoading(false);
+
+      router.push(ROUTES.HOME);
     } catch (e) {
       setIsLoading(false);
+
+      router.push(ROUTES.SIGNUP);
     }
   };
 

--- a/app/_lib/util/http.ts
+++ b/app/_lib/util/http.ts
@@ -1,0 +1,13 @@
+import { HTTP_RESPONSE_ERROR_MESSAGE } from '@constants/http';
+
+export const isExpiredAccessToken = (token: string) => {
+  return token.trim().length > 0;
+};
+
+export const isNotRegisteredMember = (message: string) => {
+  return message.includes(HTTP_RESPONSE_ERROR_MESSAGE.NOT_REGISTERED_MEMBER);
+};
+
+export const isNotExistAuthHeader = (message: string) => {
+  return message.includes(HTTP_RESPONSE_ERROR_MESSAGE.NOT_EXIST_AUTH);
+};

--- a/app/_lib/util/storage.ts
+++ b/app/_lib/util/storage.ts
@@ -1,13 +1,13 @@
 import { AUTH_TOKEN, COOKIE_CONFIG } from '@constants/auth';
 import { getCookie, setCookie } from 'cookies-next';
 
+export const LOTTOFOLIO_USER = 'LOTTOFOLIO_USER';
+
 export const storage = {
   getAccessToken: () => getCookie(AUTH_TOKEN.ACCESS) as string,
   getRefreshToken: () => getCookie(AUTH_TOKEN.REFRESH) as string,
+  getUserId: () => getCookie(LOTTOFOLIO_USER) as string,
   setAccessToken: (token: string) => setCookie(AUTH_TOKEN.ACCESS, token, COOKIE_CONFIG.ACCESS),
   setRefreshToken: (token: string) => setCookie(AUTH_TOKEN.REFRESH, token, COOKIE_CONFIG.REFRESH),
-};
-
-export const isExpiredAccessToken = (token: string) => {
-  return token.trim().length > 0;
+  setUserId: (userId: string) => setCookie(LOTTOFOLIO_USER, userId, COOKIE_CONFIG.REFRESH),
 };

--- a/app/_store/auth.ts
+++ b/app/_store/auth.ts
@@ -1,18 +1,18 @@
 import { create } from 'zustand';
 
-export interface AuthActions {
-  /**
-   * 로그인 여부 설정
-   */
-  setIsLoggedIn: (value: boolean) => void;
-}
-
 export interface AuthState {
   /**
    * 로그인 여부
    */
   isLoggedIn: boolean;
   actions: AuthActions;
+}
+
+export interface AuthActions {
+  /**
+   * 로그인 여부 설정
+   */
+  setIsLoggedIn: (value: boolean) => void;
 }
 
 export const authStore = create<AuthState>(set => ({

--- a/app/_store/member.ts
+++ b/app/_store/member.ts
@@ -1,0 +1,29 @@
+import { create } from 'zustand';
+
+export interface MemeberState {
+  memberInfo: {
+    email: string;
+    nickname: string;
+  };
+  actions: MemberActions;
+}
+
+export interface MemberActions {
+  setMemberInfo: (value: MemeberState['memberInfo']) => void;
+}
+
+export const memeberStore = create<MemeberState>(set => ({
+  memberInfo: {
+    email: '',
+    nickname: '',
+  },
+  actions: {
+    setMemberInfo: (value: MemeberState['memberInfo']) => set(() => ({ memberInfo: value })),
+  },
+}));
+
+// State
+export const useMemeberInfo = () => memeberStore(state => state.memberInfo);
+
+// Actions
+export const useMemberActions = () => memeberStore(state => state.actions);

--- a/app/_types/response.ts
+++ b/app/_types/response.ts
@@ -1,11 +1,19 @@
+import type { HttpStatusCode } from 'axios';
+
 export interface AuthResponse {
   id_token: string;
   refresh_token: string;
   nickname: string;
+  email: string;
 }
 
 export interface MemberResponse {
-  userId: string;
+  user_id: string;
   email: string;
   nickname: string;
 }
+
+export type APIErrorResponse = {
+  status: HttpStatusCode;
+  statusText: string;
+};


### PR DESCRIPTION
## 📌 이슈 번호
- close #19 

## ✨ 작업 내용
- [x] 기존 회원 여부에 따른 회원가입 페이지 또는 홈 페이지로 리다이렉트
- [x] 회원인 경우, 회원가입 페이지 접근 막기

## 📝 작업 상세 내용

## 🎨 구현 스크린샷
### 1️⃣ 등록된 회원이 아닌 경우
- DB에서 회원 정보를 삭제한 뒤, 로그인하는 상황
- 회원가입 페이지로 리다이렉트되며, 회원가입이 완료되면 쿠키에 userId가 저장됨


https://github.com/DDD-Community/DDD-9-WEB3-front/assets/76807107/cb267d0b-ed97-477a-830c-34a844a99948

### 2️⃣ 이미 등록된 회원인 경우
- 이미 DB에 등록된 회원이 로그인하는 상황
- 로그인이 정상적으로 처리되면 홈으로 리다이렉트됨

https://github.com/DDD-Community/DDD-9-WEB3-front/assets/76807107/c9458916-70fa-4f43-93ac-2e6f5dfaeabc


## 💎 TODO
