### PR TITLE
feat: 스크랩북 페이지 API 연동

### DIFF
--- a/app/_apis/member.ts
+++ b/app/_apis/member.ts
@@ -1,30 +1,27 @@
-import { MemberResponse } from '@/_types/response';
+import type { MemberInfoParams, MemberResponse } from '@/_types/response/member';
 
 import instance from './core';
 
-export interface MemberInfoParams {
-  email: string;
-  nickname: string;
-}
+const MEMBER_API_URL = '/api/member';
 
 export const memberApi = {
   /**
    * @description 회원정보 조회
    */
-  getMember: () => instance.get<unknown, MemberResponse>(`/api/member`),
+  getMember: () => instance.get<unknown, MemberResponse>(MEMBER_API_URL),
   /**
    * @description 회원정보 등록
    */
-  registerMember: (info: MemberInfoParams) =>
-    instance.post<MemberInfoParams, MemberResponse>(`/api/member`, info),
+  postMember: (info: MemberInfoParams) =>
+    instance.post<MemberInfoParams, MemberResponse>(MEMBER_API_URL, info),
 
   /**
    * @description 회원정보 삭제
    */
-  deleteMember: () => instance.delete(`/api/member`),
+  deleteMember: () => instance.delete(MEMBER_API_URL),
   /**
    * @description 회원정보 수정
    */
-  updateMember: (info: MemberInfoParams) =>
-    instance.patch<MemberInfoParams, MemberResponse>(`/api/member`, info),
+  patchMember: (info: MemberInfoParams) =>
+    instance.patch<MemberInfoParams, MemberResponse>(MEMBER_API_URL, info),
 };

--- a/app/_apis/scrap.ts
+++ b/app/_apis/scrap.ts
@@ -1,17 +1,23 @@
-import type { LottoStore, ScrapResponse } from '@/_types/response/scrap';
+import type { ScrapParams, ScrapResponse } from '@/_types/response/scrap';
 
 import instance from './core';
+
+const SCRAP_API_URL = '/api/scrap/store';
 
 export const scrapApi = {
   /**
    * @description 판매점 스크랩 조회
    */
-  getScrapStore: () => instance.get<unknown, ScrapResponse['get']>('/api/scrap/store'),
+  getScrapStore: () => instance.get<unknown, ScrapResponse['get']>(SCRAP_API_URL),
+  /**
+   * @description 판매점 스크랩 등록
+   */
+  postScrapStore: (storeId: ScrapParams) => instance.post<ScrapParams>(SCRAP_API_URL, { storeId }),
   /**
    * @description 판매점 스크랩 삭제
    */
-  deleteScrapStore: (storeId: LottoStore['storeId']) =>
-    instance.delete('/api/scrap/store', {
+  deleteScrapStore: (storeId: ScrapParams) =>
+    instance.delete(SCRAP_API_URL, {
       params: {
         storeId,
       },

--- a/app/_apis/scrap.ts
+++ b/app/_apis/scrap.ts
@@ -1,4 +1,4 @@
-import { ScrapResponse } from '@/_types/response';
+import type { ScrapResponse } from '@/_types/response/scrap';
 
 import instance from './core';
 
@@ -6,5 +6,5 @@ export const scrapApi = {
   /**
    * @description 판매점 스크랩 조회
    */
-  getScrapStore: () => instance.get<unknown, ScrapResponse>(`/api/scrap/store`),
+  getScrapStore: () => instance.get<unknown, ScrapResponse['get']>(`/api/scrap/store`),
 };

--- a/app/_apis/scrap.ts
+++ b/app/_apis/scrap.ts
@@ -1,4 +1,4 @@
-import type { ScrapResponse } from '@/_types/response/scrap';
+import type { LottoStore, ScrapResponse } from '@/_types/response/scrap';
 
 import instance from './core';
 
@@ -6,5 +6,14 @@ export const scrapApi = {
   /**
    * @description 판매점 스크랩 조회
    */
-  getScrapStore: () => instance.get<unknown, ScrapResponse['get']>(`/api/scrap/store`),
+  getScrapStore: () => instance.get<unknown, ScrapResponse['get']>('/api/scrap/store'),
+  /**
+   * @description 판매점 스크랩 삭제
+   */
+  deleteScrapStore: (storeId: LottoStore['storeId']) =>
+    instance.delete('/api/scrap/store', {
+      params: {
+        storeId,
+      },
+    }),
 };

--- a/app/_components/common/AgreeForm.tsx
+++ b/app/_components/common/AgreeForm.tsx
@@ -24,7 +24,7 @@ const AgreeForm = ({
 }: PropsWithChildren<AgreeFormProps>) => {
   return (
     <Form onSubmit={onSubmit}>
-      <TopNavigation version="CLOSE" path={navigationPath} />
+      <TopNavigation version="CLOSE" isXMargin={false} path={navigationPath} />
       <FormBody>
         <div>
           <Title>{title}</Title>

--- a/app/_components/common/AgreeForm.tsx
+++ b/app/_components/common/AgreeForm.tsx
@@ -24,7 +24,7 @@ const AgreeForm = ({
 }: PropsWithChildren<AgreeFormProps>) => {
   return (
     <Form onSubmit={onSubmit}>
-      <TopNavigation version="CLOSE" isXMargin={false} path={navigationPath} />
+      <TopNavigation version="CLOSE" $isXMargin={false} path={navigationPath} />
       <FormBody>
         <div>
           <Title>{title}</Title>

--- a/app/_components/common/Modal.tsx
+++ b/app/_components/common/Modal.tsx
@@ -57,6 +57,7 @@ const ModalContent = styled.div`
   line-height: 133%;
   letter-spacing: -0.18px;
   padding: 1.25rem 0 1.8rem;
+  white-space: pre-line;
 `;
 
 const ButtonGroup = styled.div`

--- a/app/_components/common/Spinner.tsx
+++ b/app/_components/common/Spinner.tsx
@@ -1,5 +1,18 @@
+import { Box, CircularProgress } from '@mui/material';
+import palette from '@styles/palette';
+
 const Spinner = () => {
-  return <div>Spinner</div>;
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        margin: '3rem 0',
+        '.MuiCircularProgress-root': { color: palette.grey_60 },
+      }}
+    >
+      <CircularProgress size="1.5rem" sx={{ margin: '0 auto' }} />
+    </Box>
+  );
 };
 
 export default Spinner;

--- a/app/_components/common/TopNavigation.tsx
+++ b/app/_components/common/TopNavigation.tsx
@@ -13,17 +13,17 @@ const NAVIGATION_VERSION = {
 } as const;
 
 interface TopNavigationProps {
+  $isXMargin?: boolean;
   version: keyof typeof NAVIGATION_VERSION;
-  isXMargin?: boolean;
   title?: string;
   path?: (typeof ROUTES)[keyof typeof ROUTES];
 }
 
-const TopNavigation = ({ version, isXMargin = true, title, path }: TopNavigationProps) => {
+const TopNavigation = ({ $isXMargin = true, version, title, path }: TopNavigationProps) => {
   const router = useRouter();
 
   return (
-    <NavigationBar isXMargin={isXMargin}>
+    <NavigationBar $isXMargin={$isXMargin}>
       {(version === NAVIGATION_VERSION.BACK || version === NAVIGATION_VERSION.BOTH) && (
         <BackButton type="button" onClick={() => router.back()}>
           <IconBack />
@@ -41,9 +41,9 @@ const TopNavigation = ({ version, isXMargin = true, title, path }: TopNavigation
 
 export default TopNavigation;
 
-const NavigationBar = styled.div<{ isXMargin: boolean }>`
+const NavigationBar = styled.div<{ $isXMargin: boolean }>`
   position: relative;
-  margin: ${({ isXMargin }) => (isXMargin ? '1.25rem' : '1.25rem 0')};
+  margin: ${({ $isXMargin }) => ($isXMargin ? '1.25rem' : '1.25rem 0')};
   height: 1.5rem;
   display: flex;
   justify-content: center;

--- a/app/_components/common/TopNavigation.tsx
+++ b/app/_components/common/TopNavigation.tsx
@@ -14,15 +14,16 @@ const NAVIGATION_VERSION = {
 
 interface TopNavigationProps {
   version: keyof typeof NAVIGATION_VERSION;
+  isXMargin?: boolean;
   title?: string;
   path?: (typeof ROUTES)[keyof typeof ROUTES];
 }
 
-const TopNavigation = ({ version, title, path }: TopNavigationProps) => {
+const TopNavigation = ({ version, isXMargin = true, title, path }: TopNavigationProps) => {
   const router = useRouter();
 
   return (
-    <NavigationBar>
+    <NavigationBar isXMargin={isXMargin}>
       {(version === NAVIGATION_VERSION.BACK || version === NAVIGATION_VERSION.BOTH) && (
         <BackButton type="button" onClick={() => router.back()}>
           <IconBack />
@@ -40,9 +41,9 @@ const TopNavigation = ({ version, title, path }: TopNavigationProps) => {
 
 export default TopNavigation;
 
-const NavigationBar = styled.div`
+const NavigationBar = styled.div<{ isXMargin: boolean }>`
   position: relative;
-  margin: 1.25rem 0;
+  margin: ${({ isXMargin }) => (isXMargin ? '1.25rem' : '1.25rem 0')};
   height: 1.5rem;
   display: flex;
   justify-content: center;

--- a/app/_components/common/index.ts
+++ b/app/_components/common/index.ts
@@ -1,6 +1,8 @@
 export { default as AgreeForm } from './AgreeForm';
+export { default as BottomSheet } from './BottomSheet';
 export { default as Button } from './Button';
 export { default as CheckBox } from './CheckBox';
 export { default as Modal } from './Modal';
+export { default as Spinner } from './Spinner';
 export { default as Toast } from './Toast';
 export { default as TopNavigation } from './TopNavigation';

--- a/app/_components/scrap/ScrapStore.tsx
+++ b/app/_components/scrap/ScrapStore.tsx
@@ -5,11 +5,17 @@ import IconDropArrow from '@assets/svg/dropArrow.svg';
 import palette from '@styles/palette';
 import { styled } from 'styled-components';
 
-const ScrapStore = () => {
+import type { LottoStore } from '@/_types/response/scrap';
+
+interface ScrapStoreProps {
+  storeInfo: LottoStore;
+}
+
+const ScrapStore = ({ storeInfo }: ScrapStoreProps) => {
   return (
     <Wrapper>
       <ScrapHeader>
-        <StoreName>잉크와복권 화곡2호점</StoreName>
+        <StoreName>{storeInfo.storeName}</StoreName>
         <ScrapButton>
           <IconScrap />
         </ScrapButton>
@@ -24,11 +30,11 @@ const ScrapStore = () => {
       <ScrapFooter>
         <StoreInfo>
           <IconAddress />
-          <Description>서울 강서구 가로공원로76가길 12</Description>
+          <Description>{storeInfo.address}</Description>
         </StoreInfo>
         <StoreInfo>
           <IconContact />
-          <Description>010-1234-5678</Description>
+          <Description>{storeInfo.phone}</Description>
         </StoreInfo>
       </ScrapFooter>
     </Wrapper>
@@ -92,4 +98,8 @@ const StoreInfo = styled.div`
 
 const Description = styled.span`
   margin-left: 4px;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  word-break: break-all;
 `;

--- a/app/_components/scrap/ScrapStore.tsx
+++ b/app/_components/scrap/ScrapStore.tsx
@@ -20,7 +20,7 @@ const ScrapStore = ({ storeInfo }: ScrapStoreProps) => {
   const { mutate: deleteScrapStore } = useDeleteScrap(storeInfo.storeId);
 
   const handleScrapButtonClick = () => {
-    setIsOpenDeleteScrapModal(true);
+    deleteScrapStore();
   };
 
   return (
@@ -28,7 +28,7 @@ const ScrapStore = ({ storeInfo }: ScrapStoreProps) => {
       <Wrapper>
         <ScrapHeader>
           <StoreName>{storeInfo.storeName}</StoreName>
-          <ScrapButton onClick={handleScrapButtonClick}>
+          <ScrapButton onClick={() => setIsOpenDeleteScrapModal(true)}>
             <IconScrap />
           </ScrapButton>
         </ScrapHeader>
@@ -55,7 +55,7 @@ const ScrapStore = ({ storeInfo }: ScrapStoreProps) => {
         content={`스크랩북에서\n삭제하시겠어요?`}
         buttonContent="삭제하기"
         onClose={() => setIsOpenDeleteScrapModal(false)}
-        onClick={deleteScrapStore}
+        onClick={handleScrapButtonClick}
       />
     </>
   );

--- a/app/_components/scrap/ScrapStore.tsx
+++ b/app/_components/scrap/ScrapStore.tsx
@@ -2,7 +2,11 @@ import IconAddress from '@assets/svg/address.svg';
 import IconScrap from '@assets/svg/bookmarkIcon.svg';
 import IconContact from '@assets/svg/contact.svg';
 import IconDropArrow from '@assets/svg/dropArrow.svg';
+import { Modal } from '@components/common';
+import { ERROR } from '@constants/message';
+import { useDeleteScrap } from '@hooks/queries/useScrap';
 import palette from '@styles/palette';
+import { useState } from 'react';
 import { styled } from 'styled-components';
 
 import type { LottoStore } from '@/_types/response/scrap';
@@ -12,32 +16,48 @@ interface ScrapStoreProps {
 }
 
 const ScrapStore = ({ storeInfo }: ScrapStoreProps) => {
+  const [isOpenDeleteScrapModal, setIsOpenDeleteScrapModal] = useState(false);
+  const { mutate: deleteScrapStore } = useDeleteScrap(storeInfo.storeId);
+
+  const handleScrapButtonClick = () => {
+    setIsOpenDeleteScrapModal(true);
+  };
+
   return (
-    <Wrapper>
-      <ScrapHeader>
-        <StoreName>{storeInfo.storeName}</StoreName>
-        <ScrapButton>
-          <IconScrap />
-        </ScrapButton>
-      </ScrapHeader>
-      <ScrapBody>
-        <WinningInfo>1등 당첨 횟수</WinningInfo>
-        <WinningCount>6회</WinningCount>
-        <WinningListButton>
-          <IconDropArrow />
-        </WinningListButton>
-      </ScrapBody>
-      <ScrapFooter>
-        <StoreInfo>
-          <IconAddress />
-          <Description>{storeInfo.address}</Description>
-        </StoreInfo>
-        <StoreInfo>
-          <IconContact />
-          <Description>{storeInfo.phone}</Description>
-        </StoreInfo>
-      </ScrapFooter>
-    </Wrapper>
+    <>
+      <Wrapper>
+        <ScrapHeader>
+          <StoreName>{storeInfo.storeName}</StoreName>
+          <ScrapButton onClick={handleScrapButtonClick}>
+            <IconScrap />
+          </ScrapButton>
+        </ScrapHeader>
+        <ScrapBody>
+          <WinningInfo>1등 당첨 횟수</WinningInfo>
+          <WinningCount>6회</WinningCount>
+          <WinningListButton>
+            <IconDropArrow />
+          </WinningListButton>
+        </ScrapBody>
+        <ScrapFooter>
+          <StoreInfo>
+            <IconAddress />
+            <Description>{storeInfo.address}</Description>
+          </StoreInfo>
+          <StoreInfo>
+            <IconContact />
+            <Description>{storeInfo.phone || ERROR.NO_DATA}</Description>
+          </StoreInfo>
+        </ScrapFooter>
+      </Wrapper>
+      <Modal
+        isOpen={isOpenDeleteScrapModal}
+        content={`스크랩북에서\n삭제하시겠어요?`}
+        buttonContent="삭제하기"
+        onClose={() => setIsOpenDeleteScrapModal(false)}
+        onClick={deleteScrapStore}
+      />
+    </>
   );
 };
 
@@ -51,6 +71,7 @@ const Wrapper = styled.div`
 const ScrapHeader = styled.header`
   display: flex;
   justify-content: space-between;
+  align-items: center;
 `;
 
 const StoreName = styled.h1`
@@ -59,7 +80,9 @@ const StoreName = styled.h1`
   letter-spacing: -0.01rem;
 `;
 
-const ScrapButton = styled.button``;
+const ScrapButton = styled.button`
+  padding-top: 0.18rem;
+`;
 
 const ScrapBody = styled.div`
   display: flex;

--- a/app/_constants/message.ts
+++ b/app/_constants/message.ts
@@ -7,4 +7,5 @@ export const ERROR = {
     title: '일시적인 오류입니다',
     description: '서비스 이용에 불편을 드려서 죄송합니다. 잠시 후 재시도해주세요.',
   },
+  NO_DATA: '정보를 찾을 수 없습니다.',
 };

--- a/app/_features/ScrapbookPage.tsx
+++ b/app/_features/ScrapbookPage.tsx
@@ -1,16 +1,25 @@
 'use client';
 
-import { TopNavigation } from '@components/common';
+import { Spinner, TopNavigation } from '@components/common';
 import AuthProvider from '@components/providers/AuthProvider';
 import ScrapStore from '@components/scrap/ScrapStore';
+import { useGetScrap } from '@hooks/queries/useScrap';
+import { useIsLoggedIn } from '@store/auth';
 import { styled } from 'styled-components';
 
 const ScrapbookPage = () => {
+  const isLoggedIn = useIsLoggedIn();
+  const { data: scrapList, isLoading } = useGetScrap({ enabled: isLoggedIn });
+
   return (
     <AuthProvider>
       <Wrapper>
         <TopNavigation version="BACK" title="스크랩북" />
-        <ScrapStore />
+        {isLoading ? (
+          <Spinner />
+        ) : (
+          scrapList?.map(scrapItem => <ScrapStore key={scrapItem.storeId} storeInfo={scrapItem} />)
+        )}
       </Wrapper>
     </AuthProvider>
   );

--- a/app/_features/ScrapbookPage.tsx
+++ b/app/_features/ScrapbookPage.tsx
@@ -20,7 +20,7 @@ export default ScrapbookPage;
 
 const Wrapper = styled.div`
   height: calc(100vh - 2.9rem);
-  padding: 2.9rem 1.25rem 0 1.25rem;
+  padding-top: 2.9rem;
   display: flex;
   flex-direction: column;
 `;

--- a/app/_features/SignupPage.tsx
+++ b/app/_features/SignupPage.tsx
@@ -63,7 +63,7 @@ export default function SignupPage() {
       return;
     }
 
-    const { user_id } = await memberApi.registerMember(memberInfo);
+    const { user_id } = await memberApi.postMember(memberInfo);
 
     storage.setUserId(user_id);
     setIsLoggedIn(true);

--- a/app/_features/TermPage.tsx
+++ b/app/_features/TermPage.tsx
@@ -8,7 +8,7 @@ import { styled } from 'styled-components';
 export default function TermPage() {
   return (
     <Wrapper>
-      <TopNavigation version="BOTH" path={ROUTES.HOME} />
+      <TopNavigation version="BOTH" isXMargin={false} path={ROUTES.HOME} />
       <Title>서비스 이용약관</Title>
       <Content>
         <div>
@@ -366,7 +366,7 @@ export default function TermPage() {
 const Wrapper = styled.div`
   position: relative;
   height: calc(100vh - 10.8rem);
-  padding: 8.1rem 1.2rem 2.7rem;
+  padding: 8.1rem 1.25rem 2.7rem;
   display: flex;
   flex-direction: column;
   justify-content: space-between;

--- a/app/_features/TermPage.tsx
+++ b/app/_features/TermPage.tsx
@@ -8,7 +8,7 @@ import { styled } from 'styled-components';
 export default function TermPage() {
   return (
     <Wrapper>
-      <TopNavigation version="BOTH" isXMargin={false} path={ROUTES.HOME} />
+      <TopNavigation version="BOTH" $isXMargin={false} path={ROUTES.HOME} />
       <Title>서비스 이용약관</Title>
       <Content>
         <div>

--- a/app/_hooks/queries/useMember.ts
+++ b/app/_hooks/queries/useMember.ts
@@ -3,7 +3,7 @@ import { getQueryKey } from '@lib/util/queryKey';
 import { useQuery, type UseQueryOptions } from '@tanstack/react-query';
 import type { AxiosError } from 'axios';
 
-import { MemberResponse } from '@/_types/response';
+import type { MemberResponse } from '@/_types/response/member';
 
 const MEMBER_QUERYKEY = getQueryKey('member');
 

--- a/app/_hooks/queries/useScrap.ts
+++ b/app/_hooks/queries/useScrap.ts
@@ -1,9 +1,15 @@
 import { scrapApi } from '@apis/scrap';
 import { getQueryKey } from '@lib/util/queryKey';
-import { useQuery, type UseQueryOptions } from '@tanstack/react-query';
-import type { AxiosError } from 'axios';
+import {
+  useMutation,
+  type UseMutationOptions,
+  useQuery,
+  useQueryClient,
+  type UseQueryOptions,
+} from '@tanstack/react-query';
+import type { AxiosError, AxiosResponse } from 'axios';
 
-import type { ScrapData, ScrapResponse } from '@/_types/response/scrap';
+import type { LottoStore, ScrapData, ScrapResponse } from '@/_types/response/scrap';
 
 const SCRAP_QUERYKEY = getQueryKey('scrap');
 
@@ -13,6 +19,7 @@ export const useGetScrap = (
   useQuery<ScrapResponse['get'], AxiosError, ScrapData['get']>({
     queryKey: SCRAP_QUERYKEY.lists(),
     queryFn: scrapApi.getScrapStore,
+    ...options,
     select: data =>
       data.map(scrap => ({
         storeId: scrap.store_id,
@@ -27,5 +34,19 @@ export const useGetScrap = (
         address: scrap.new_address,
         phone: scrap.phone_no,
       })),
-    ...options,
   });
+
+export const useDeleteScrap = (
+  storeId: LottoStore['storeId'],
+  options?: UseMutationOptions<AxiosResponse, AxiosError>,
+) => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: () => scrapApi.deleteScrapStore(storeId),
+    ...options,
+    onSuccess: () => {
+      queryClient.invalidateQueries(SCRAP_QUERYKEY.lists());
+    },
+  });
+};

--- a/app/_hooks/queries/useScrap.ts
+++ b/app/_hooks/queries/useScrap.ts
@@ -9,7 +9,7 @@ import {
 } from '@tanstack/react-query';
 import type { AxiosError, AxiosResponse } from 'axios';
 
-import type { LottoStore, ScrapData, ScrapResponse } from '@/_types/response/scrap';
+import type { ScrapData, ScrapParams, ScrapResponse } from '@/_types/response/scrap';
 
 const SCRAP_QUERYKEY = getQueryKey('scrap');
 
@@ -36,8 +36,23 @@ export const useGetScrap = (
       })),
   });
 
+export const usePostScrap = (
+  storeId: ScrapParams,
+  options?: UseMutationOptions<AxiosResponse, AxiosError>,
+) => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: () => scrapApi.postScrapStore(storeId),
+    ...options,
+    onSuccess: () => {
+      queryClient.invalidateQueries(SCRAP_QUERYKEY.lists());
+    },
+  });
+};
+
 export const useDeleteScrap = (
-  storeId: LottoStore['storeId'],
+  storeId: ScrapParams,
   options?: UseMutationOptions<AxiosResponse, AxiosError>,
 ) => {
   const queryClient = useQueryClient();

--- a/app/_hooks/queries/useScrap.ts
+++ b/app/_hooks/queries/useScrap.ts
@@ -3,9 +3,29 @@ import { getQueryKey } from '@lib/util/queryKey';
 import { useQuery, type UseQueryOptions } from '@tanstack/react-query';
 import type { AxiosError } from 'axios';
 
-import { ScrapResponse } from '@/_types/response';
+import type { ScrapData, ScrapResponse } from '@/_types/response/scrap';
 
 const SCRAP_QUERYKEY = getQueryKey('scrap');
 
-export const useGetScrap = (options?: UseQueryOptions<ScrapResponse, AxiosError>) =>
-  useQuery({ queryKey: SCRAP_QUERYKEY.lists(), queryFn: scrapApi.getScrapStore, ...options });
+export const useGetScrap = (
+  options?: UseQueryOptions<ScrapResponse['get'], AxiosError, ScrapData['get']>,
+) =>
+  useQuery<ScrapResponse['get'], AxiosError, ScrapData['get']>({
+    queryKey: SCRAP_QUERYKEY.lists(),
+    queryFn: scrapApi.getScrapStore,
+    select: data =>
+      data.map(scrap => ({
+        storeId: scrap.store_id,
+        storeName: scrap.store_name,
+        si: scrap.address1,
+        gu: scrap.address2,
+        dong: scrap.address3,
+        isGoodPlace: scrap.is_good_place,
+        isScrap: scrap.is_scrap,
+        latitude: scrap.latitude,
+        longitude: scrap.longitude,
+        address: scrap.new_address,
+        phone: scrap.phone_no,
+      })),
+    ...options,
+  });

--- a/app/_types/response.ts
+++ b/app/_types/response.ts
@@ -13,11 +13,6 @@ export interface MemberResponse {
   nickname: string;
 }
 
-export interface ScrapResponse {
-  user_id: string;
-  store_id: string;
-}
-
 export type APIErrorResponse = {
   status: HttpStatusCode;
   statusText: string;

--- a/app/_types/response.ts
+++ b/app/_types/response.ts
@@ -7,12 +7,6 @@ export interface AuthResponse {
   email: string;
 }
 
-export interface MemberResponse {
-  user_id: string;
-  email: string;
-  nickname: string;
-}
-
 export type APIErrorResponse = {
   status: HttpStatusCode;
   statusText: string;

--- a/app/_types/response/member.ts
+++ b/app/_types/response/member.ts
@@ -1,0 +1,10 @@
+interface MemberInfo {
+  email: string;
+  nickname: string;
+}
+
+export type MemberInfoParams = MemberInfo;
+
+export interface MemberResponse extends MemberInfo {
+  user_id: string;
+}

--- a/app/_types/response/scrap.ts
+++ b/app/_types/response/scrap.ts
@@ -1,0 +1,33 @@
+export interface LottoStore {
+  storeId: string;
+  storeName: string;
+  si: string;
+  gu: string;
+  dong: string;
+  isGoodPlace: boolean;
+  isScrap: boolean;
+  latitude: number;
+  longitude: number;
+  address: string;
+  phone: string;
+}
+
+export interface ScrapData {
+  get: LottoStore[];
+}
+
+export interface ScrapResponse {
+  get: {
+    store_id: string;
+    store_name: string;
+    address1: string;
+    address2: string;
+    address3: string;
+    is_good_place: boolean;
+    is_scrap: boolean;
+    latitude: number;
+    longitude: number;
+    new_address: string;
+    phone_no: string;
+  }[];
+}

--- a/app/_types/response/scrap.ts
+++ b/app/_types/response/scrap.ts
@@ -16,6 +16,8 @@ export interface ScrapData {
   get: LottoStore[];
 }
 
+export type ScrapParams = LottoStore['storeId'];
+
 export interface ScrapResponse {
   get: {
     store_id: string;


### PR DESCRIPTION
## 📌 이슈 번호
- close #32 

## ✨ 작업 내용
- [x] TopNavigation 컴포넌트에 `$isXMargin` prop 추가
- [x] Spinner 공통 컴포넌트 구현
- [x] 판매점 스크랩 조회 API 서버 데이터 가공 처리(`snake_case` -> `camelCase`)
- [x] 스크랩북 페이지의 판매점 목록 구현
- [x] 스크랩 판매점 삭제 기능 구현
- [x] 판매점 스크랩 등록(POST) API hook 정의
- [x] API response 타입 분리

## 📝 작업 상세 내용
- 판매점 스크랩 조회 데이터 중 `phone_no` 값이 없는 경우가 간혹 있어서 `정보를 찾을 수 없습니다.` 메시지로 대체했습니다.
- 기존 `_constants/index.ts` 파일을 `_constants/message.ts`로 변경했습니다!

## 🎨 구현 스크린샷

https://github.com/DDD-Community/DDD-9-WEB3-front/assets/76807107/a43af4be-7736-4a32-a50a-7f83766afe5b


## 💎 TODO
